### PR TITLE
Update compressor_performance.py

### DIFF
--- a/compressor_performance.py
+++ b/compressor_performance.py
@@ -11,6 +11,7 @@ air = pm.get("ig.air")
 # warnings.simplefilter("always")
 
 r_air = pm.units.const_Ru/(air.mw()/1000000)
+# Wrong order of magnitude for weight from air.mw: 28964 g/kmol --> Corrected Value by dividing with 1e6: 0,0289 g/mol
 
 
 def visc(t):

--- a/compressor_performance.py
+++ b/compressor_performance.py
@@ -10,7 +10,7 @@ pm.config["unit_energy"], pm.config["unit_molar"], pm.config["unit_pressure"] = 
 air = pm.get("ig.air")
 # warnings.simplefilter("always")
 
-r_air = pm.units.const_Ru/air.mw()
+r_air = pm.units.const_Ru/(air.mw()/1000000)
 
 
 def visc(t):


### PR DESCRIPTION
Hello Daniel, 

I´ve tried your code and got several errors caused by the wrong order of magnitude for the molecular weight of air. By dividing it by 10^6 I get 0,02897 kg/mol and therefore the correct value for the specific gas constant R (287,05). Maybe the error is anywhere else on my computer (e.g. version compatibility) , but this was the only way to make it work.

Great thesis and thank you very much for publishing your work. Currently I´m writing my own master thesis and I´d like to use your code for mass estimations for the FC´s, if it´s possible. Somehow I got a weight of 275890 kg for the compressor, when I´m using your default values for the calculation. May I ask you, what did I do wrong? 

Best regards 
Dominic 
